### PR TITLE
wrapped Object class for raw values

### DIFF
--- a/implementation/legacy/src/main/java/org/codemc/worldguardwrapper/implementation/legacy/utility/WorldGuardFlagUtilities.java
+++ b/implementation/legacy/src/main/java/org/codemc/worldguardwrapper/implementation/legacy/utility/WorldGuardFlagUtilities.java
@@ -40,6 +40,8 @@ public class WorldGuardFlagUtilities {
             wrappedFlag = new WrappedPrimitiveFlag(flag);
         } else if (type.equals(Vector.class)) {
             wrappedFlag = new WrappedPrimitiveFlag(flag);
+        } else if (type.equals(Object.class)) {
+            wrappedFlag = new WrappedPrimitiveFlag(flag);
         } else {
             throw new IllegalArgumentException("Unsupported flag type " + type.getName());
         }

--- a/implementation/v6/src/main/java/org/codemc/worldguardwrapper/implementation/v6/utility/WorldGuardFlagUtilities.java
+++ b/implementation/v6/src/main/java/org/codemc/worldguardwrapper/implementation/v6/utility/WorldGuardFlagUtilities.java
@@ -39,6 +39,8 @@ public class WorldGuardFlagUtilities {
             wrappedFlag = new WrappedPrimitiveFlag(flag);
         } else if (type.equals(Vector.class)) {
             wrappedFlag = new WrappedPrimitiveFlag(flag);
+        } else if (type.equals(Object.class)) {
+            wrappedFlag = new WrappedPrimitiveFlag(flag);
         } else {
             throw new IllegalArgumentException("Unsupported flag type " + type.getName());
         }

--- a/implementation/v7/src/main/java/org/codemc/worldguardwrapper/implementation/v7/utility/WorldGuardFlagUtilities.java
+++ b/implementation/v7/src/main/java/org/codemc/worldguardwrapper/implementation/v7/utility/WorldGuardFlagUtilities.java
@@ -38,6 +38,8 @@ public class WorldGuardFlagUtilities {
             wrappedFlag = new WrappedPrimitiveFlag(flag);
         } else if (type.equals(Vector.class)) {
             wrappedFlag = new WrappedPrimitiveFlag(flag);
+        } else if (type.equals(Object.class)) {
+            wrappedFlag = new WrappedPrimitiveFlag(flag);
         } else {
             throw new IllegalArgumentException("Unsupported flag type " + type.getName());
         }


### PR DESCRIPTION
This adds support for Object class when getting the flag.
This is used in some edge cases that require getting the raw value of the flag instead of the mapped type.